### PR TITLE
mysql: removed extra semicolon that was causing problems

### DIFF
--- a/GameEngine/Database/db_MYSQL.php
+++ b/GameEngine/Database/db_MYSQL.php
@@ -130,7 +130,6 @@ class MYSQL_DB {
 		$query1 = mysql_query("SELECT * FROM ".TB_PREFIX."fdata WHERE vref = ".$villaggi_array['wref']."");
 		$strutture= mysql_fetch_array($query1);
 		return $strutture;
-		}
 	}
 	
 	function removeMeSit($uid, $uid2) {


### PR DESCRIPTION
An extra semicolon was closing the class as well as the function, excluding all functions below from MYSQL_DB class
