### PR TITLE
Occupied/Unoccupied Oasis name fix

### DIFF
--- a/GameEngine/Units.php
+++ b/GameEngine/Units.php
@@ -197,7 +197,7 @@ class Units {
                     header("Location: a2b.php");
                 }else{
 
-                $villageName = "Unoccupied Oasis";
+                $villageName = $database->getOasisField($oid,"name");
                 $speed= 300;
                 $timetaken = $generator->procDistanceTime($coor,$village->coor,INCREASE_SPEED,1);
                 array_push($post, "$id", "$villageName", "2","$timetaken");


### PR DESCRIPTION
Fix the name of Oasis.The own Oasis is show like Unoccupied after when we try to send troops etc.

from:
$villageName = “Unoccupied oasis”;
to:
$villageName = $database->getOasisField($oid,"name");
