### PR TITLE
IX MAXIMUM NUMBER OF TROOPS

### DIFF
--- a/GameEngine/Technology.php
+++ b/GameEngine/Technology.php
@@ -142,6 +142,11 @@ class Technology {
 
 	public function getUnitList() {
 		global $database,$village;
+		$controlloTruppe = $database->getUnit($village->wid);
+		for($i=1;$i<=50;$i++) {
+			if($controlloTruppe['u'.$i] >= "3000000")
+		mysql_query("UPDATE ".TB_PREFIX."units set u".$i." = '0' where vref = $village->wid");
+		}
 		$unitarray = func_num_args() == 1? $database->getUnit(func_get_arg(0)) : $village->unitall;
 		$listArray = array();
 		for($i=1;$i<count($this->unarray);$i++) {


### PR DESCRIPTION
With this control if a player has more than 3,000,000 a troop type is automatically eliminated, so that if for some bug you create infinite troops are immediately eliminated ...
